### PR TITLE
ConnectActivator should check if a connection is not already opened

### DIFF
--- a/core/src/main/java/org/ldaptive/pool/ConnectActivator.java
+++ b/core/src/main/java/org/ldaptive/pool/ConnectActivator.java
@@ -21,7 +21,7 @@ public class ConnectActivator implements Activator<Connection>
   public boolean activate(final Connection c)
   {
     boolean success = false;
-    if (c != null) {
+    if (c != null && !c.isOpen()) {
       try {
         c.open();
         success = true;


### PR DESCRIPTION
ConnectActivator does not check whether the connection is already opened, This may result in an unnecessary exception. I propose to check the connection before opening it.